### PR TITLE
Remove .env access from library (client responsibility)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ A simple Javascript/Node client library for the Lightrail API
 Run `npm install` to install dependencies.
 
 This library has the following dependencies:
-- `dotenv` to configure & read environment variables from the file `.env`
 - `request-promise` to make async requests to the API
 - `request` to support `request-promise` (peer dependency)
 
-### Reading your API access token from process.env
+### Your API access token
 
-Create a `.env` file in the root directory of your project. In that file, add your access token in this format (note, no quotation marks around any part of it):
+It is the responsibility of the client to pass their access token to the constructor function (`new Lightrail(access_token)`).
+
+For the time being, this is done in the 'testApp.js' file by storing the access token as an environment variable and useing the 'dotenv' library to read it. To set this up: create a `.env` file in the root directory of your project. In that file, add your access token in this format (note, no quotation marks around any part of it):
 `ACCESS_TOKEN=your-lightrail-access-token`
 
 ### Testing

--- a/lightrailClient.js
+++ b/lightrailClient.js
@@ -1,16 +1,15 @@
 "use strict";
 
-require('dotenv').config();
 var rp = require('request-promise');
 
-var baseURL = 'https://api.lightrail.com/v1/';
-var customHeaders = {
-  'Content-Type': 'application/json',
-  'Authorization': 'Bearer ' + process.env.ACCESS_TOKEN
-};
 
-
-function Lightrail() {}
+function Lightrail(accessToken) {
+  this.BASE_URL = 'https://api.lightrail.com/v1/';
+  this.HEADERS = {
+    'Content-Type': 'application/json',
+    'Authorization': 'Bearer ' + accessToken
+  };
+}
 
 // **Usage note - these functions each return a promise**
 
@@ -23,8 +22,8 @@ Lightrail.prototype.createContact = function(contact) {
   // TODO: validate argument
   return rp({
     method: 'POST',
-    uri: baseURL + 'contacts',
-    headers: customHeaders,
+    uri: this.BASE_URL + 'contacts',
+    headers: this.HEADERS,
     body: {
       'userSuppliedId': contact.id,
       // TODO: handle undefined optional properties
@@ -46,8 +45,8 @@ Lightrail.prototype.createPointsCard = function(card) {
   // TODO: validate argument
   return rp({
     method: 'POST',
-    uri: baseURL + 'cards',
-    headers: customHeaders,
+    uri: this.BASE_URL + 'cards',
+    headers: this.HEADERS,
     body: {
       'userSuppliedId': card.id,
       'code': {
@@ -72,8 +71,8 @@ Lightrail.prototype.createPointsCard = function(card) {
 Lightrail.prototype.updatePoints = function(card, points, transactionId) {
   return rp({
     method: 'POST',
-    uri: baseURL + 'cards/' + card.lightrailId + '/code/transactions',
-    headers: customHeaders,
+    uri: this.BASE_URL + 'cards/' + card.lightrailId + '/code/transactions',
+    headers: this.HEADERS,
     body: {
       'value': points,
       'currency': 'XXX',
@@ -89,8 +88,8 @@ Lightrail.prototype.updatePoints = function(card, points, transactionId) {
 Lightrail.prototype.getBalance = function(card) {
   return rp({
     method: 'GET',
-    uri: baseURL + 'cards/' + card.lightrailId + '/code/balance',
-    headers: customHeaders,
+    uri: this.BASE_URL + 'cards/' + card.lightrailId + '/code/balance',
+    headers: this.HEADERS,
     json: true
   });
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "author": "Tana Jukes",
   "license": "MIT",
   "dependencies": {
-    "dotenv": "^4.0.0",
     "request": "^2.81.0",
     "request-promise": "^4.2.0"
   },

--- a/testApp.js
+++ b/testApp.js
@@ -1,8 +1,10 @@
 "use strict";
 
+require('dotenv').config();
+
 var Lightrail = require('./lightrailClient.js');
 
-var LR = new Lightrail();
+var LR = new Lightrail(process.env.ACCESS_TOKEN);
 
 console.log(LR);
 


### PR DESCRIPTION
Fixes Issue #3 

The library should not access environment variables directly. That could easily be inconvenient for the client -- for example they may have some other environment variable called 'ACCESS_TOKEN'. Instead, let it be the client's responsibility to pass in their access token from wherever they like when initializing a new Lightrail().

This commit updates the Lightrail constructor so that it expects to receive the access token as an argument. It then establishes the BASE_URL and HEADERS as local variables (which should also be treated as constants). Associated methods have been updated to refer to the new location of the base url and the headers.

The 'dotenv' dependency has been removed from the package.json (no longer required for the library) but added into the testApp file, where it is now used from the 'client side'. The readme has bee updated to reflect these changes."